### PR TITLE
Change to `npm init` behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ import utc from '@momentjs/moment/timezones/utc/'; // Note trailing slash
 // Error: folders cannot be imported (there is no index.* magic)
 ```
 
+### `npm init`
+
+Currently one of the [questions asked by `npm init`](https://nodesource.com/blog/your-first-nodejs-package/) is `entry point: (index.js)`. Accepting the default for this question adds `"main": "index.js"` to the generated `package.json` file.
+
+We propose that this behavior be changed. The question and default may remain the same, but it should generate `"exports": "./index.js"` instead.
+
 ### Prior Art
 
 * [`package.json#browser`](https://github.com/defunctzombie/package-browser-field-spec)


### PR DESCRIPTION
https://github.com/jkrems/proposal-pkg-exports/blob/npm-init/README.md#npm-init

So I’m working on the 5-minute tutorial for creating a “hello world” server using @guybedford’s new implementation, and I’d love to be able to tell users to just run `npm init` to generate a `package.json`, and have that `package.json` be ESM-signifying by default. Then users wouldn’t need to manually edit their `package.json` files as part of starting a new project that uses ESM syntax.

The issue is that one of the questions posed by `init` is `entry point: (index.js)`, which by default produces `"main": "index.js"` in the generated `package.json`.

Perhaps NPM is outside of Node’s purview, but I think once Node had its own ESM support the NPM team would probably be okay with this question’s output changing to be ESM instead. According to this package exports proposal, it would change to `"exports": "./index.js"` as the new ESM equivalent to the previous `"main": "index.js"`.

As `npm init` is targeted toward beginners, I don’t think it’s a good place to mention concepts like “CommonJS entry point” or desired package entry point parse goal. NPM should just keep it simple and output `"exports"` if it’s being run under an ESM-supporting version of Node. Unless there’s a concern about users being surprised that their new app/package won’t run under older versions of Node?

Also one could argue that perhaps it should be `index.mjs` instead; I think that’s the type of question best resolved by a user survey.