### PR TITLE
Start specifiers with leading `/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## High Level Considerations
 
 * The baseline behavior of relative imports should match a browser's with a simple file server.
-  This implies that `./x` will only ever import exactly the sibling file "x" without appending paths or extensions.
+  This implies that `/x` will only ever import exactly the sibling file "x" without appending paths or extensions.
   `"x"` is never resolved to `x.mjs` or `x/index.mjs` (or the `.js` equivalents).
 * The primary compatibility boundary are bare specifiers. Relative and absolute imports can follow simpler rules.
 * Resolution should not depend on file extensions, allowing ESM syntax in `.js` files.
@@ -51,29 +51,28 @@ Here’s a complete `package.json` example, for a hypothetical module named `@mo
   "type": "module",
   "main": "./dist/index.js",
   "exports": {
-    ".": "./src/moment.mjs",
-    "./": "./src/util/",
-    "./timezones/": "./data/timezones/",
-    "./timezones/utc": "./data/timezones/utc/index.mjs"
+    "/": "./src/util/",
+    "/timezones/": "./data/timezones/",
+    "/timezones/utc": "./data/timezones/utc/index.mjs"
   }
 }
 ```
 
-Within the `"exports"` object, the key string after the `'.'` is concatenated on the end of the name field, e.g. `import utc from '@momentjs/moment/timezones/utc'` is formed from `'@momentjs/moment'` + `'/timezones/utc'`. Note that this is string manipulation, not a file path: `"./timezones/utc"` is allowed, but just `"timezones/utc"` is not. The `.` is a placeholder representing the package name. The main entrypoint is therefore the dot string, `".": "./src/moment.mjs"`.
+Within the `"exports"` object, the key string from the `'/'` is concatenated on the end of the name field, e.g. `import utc from '@momentjs/moment/timezones/utc'` is formed from `'@momentjs/moment'` + `'/timezones/utc'`. Note that this is string manipulation, not a file path: `"./timezones/utc"` is allowed, but just `"timezones/utc"` is not. The `.` is a placeholder representing the package name. The main entrypoint is therefore the dot string, `".": "./src/moment.mjs"`.
 
-Keys that end in slashes can map to folder roots, following the [pattern in the browser import maps proposal](https://github.com/WICG/import-maps#packages-via-trailing-slashes): `"./timezones/": "./data/timezones/"` would allow `import pdt from "@momentjs/moment/timezones/pdt.mjs"` to import `./data/timezones/pdt.mjs`.
+Keys that end in slashes can map to folder roots, following the [pattern in the browser import maps proposal](https://github.com/WICG/import-maps#packages-via-trailing-slashes): `"/timezones/": "./data/timezones/"` would allow `import pdt from "@momentjs/moment/timezones/pdt.mjs"` to import `./data/timezones/pdt.mjs`.
 
-- Using `"./"` maps the root, so `"./": "./src/util/"` would allow `import tick from "@momentjs/moment/tick.mjs"` to import `./src/util/tick.mjs`.
+- Using `"/"` maps the root, so `"/": "./src/util/"` would allow `import tick from "@momentjs/moment/tick.mjs"` to import `./src/util/tick.mjs`.
 
-- Mapping a key of `"./"` to a value of `"./"` exposes all files in the package, where `"./": "./"` would allow `import privateHelpers from "@momentjs/moment/private-helpers.mjs"` to import `./private-helpers.mjs`.
+- Mapping a key of `"/"` to a value of `"/"` exposes all files in the package, where `"/": "/"` would allow `import privateHelpers from "@momentjs/moment/private-helpers.mjs"` to import `./private-helpers.mjs`.
 
-- When mapping to a folder root, both the left and right sides must end in slashes: `"./": "./dist/"`, not `".": "./dist"`.
+- When mapping to a folder root, both the left and right sides must end in slashes: `"/": "/dist/"`, not `"/": "./dist"`.
 
 - Unlike in CommonJS, there is no automatic searching for `index.js` or `index.mjs` or for file extensions. This matches the [behavior of the import maps proposal](https://github.com/WICG/import-maps#packages-via-trailing-slashes).
 
-The value of an export, e.g. `"./src/moment.mjs"`, must begin with `.` to signify a relative path (e.g. "./src" is okay, but `"/src"` or `"src"` are not). This is to reserve potential future use for `"exports"` to export things referenced via specifiers that aren’t relatively-resolved files, such as other packages or other protocols.
+The value of an export, e.g. `"/src/moment.mjs"`, must begin with `/` to signify a path within the package (e.g. "/src" is okay, but `"./src"` or `"src"` are not). This is to reserve potential future use for `"exports"` to also remap URLs or perform internal remappings of imports within the package boundary.
 
-There is the potential for collisions in the exports, such as `"./timezones/"` and `"./timezones/utc"` in the example above (e.g. if there’s a file named `utc` in the `./data/timezones` folder).
+There is the potential for collisions in the exports, such as `"/timezones/"` and `"/timezones/utc"` in the example above (e.g. if there’s a file named `utc` in the `./data/timezones` folder).
 Rough outline of a possible resolution algorithm:
 
 1. Find the package matching the base specifier, e.g. `@momentjs/moment` or `request`.


### PR DESCRIPTION
In discussions about how other types of mappings would work, we have determined that using `./` to denote paths from outside of the package, and then considering supporting other mappings such as URLs, internal package imports and plain package imports to other packages, would be a conflation of the encapsulation of this proposal.

That is, we need a clear and distinct way to separate the concept of "export mappings" into the package from the concept of "import mappings" within the package. The concern here is that we then end up with two separate fields, which doesn't seem ideal for this specification to have to deal with.

Rather if we want a single field that can scale to handle other remapping scenarios gradually, we should ensure that exports are fully disambiguated against the other forms of remappings we might want to add in future.

We considered mandating that exports should always start with `~/` but that seems like it would be quite an ask on users who just want simple export maps to understand the meaning of this syntax.

Instead this PR changes the syntax to use a leading `/` in all of the mappings so that we are already disambiguated against any other forms in future. It seems very unlikely that any package would want to be root-relative due to portability concerns, so that this is a valid assumption to make.