### PR TITLE
Support exports: false sugar

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ For `"type": "module"` packages with both `"main"` and `"exports"`, a main entry
 This allows a package to be importable as either ESM or CommonJS.
 If a `package.json` lacks `"exports"` but includes `"type": "module"`, `"main"` defines the package’s ESM entrypoint.
 
+For packages that only have a main and no exports, `"exports": false` can be used as a shorthand for `"exports": {}` providing an encapsulated package.
+
 ### Example
 
 Here’s a complete `package.json` example, for a hypothetical module named `@momentjs/moment`:


### PR DESCRIPTION
For packages that don't have any exports, and just a main, we could write:

```json
{
  "main": "index.js",
  "exports": {}
}
```

to get the exports encapsulation. This will disallow `import 'pkg/subpath'` for any subpath. Although the empty object usage there might easily be overlooked as not having any use or value to someone who wasn't aware of the details of the spec.

To make the full encapsulation case clearer, it might be nice to support a sugar for this:

```json
{
  "main": "index.js",
  "exports": false
}
```

The intent of the "exports" property is now clear to users in that it is having an effect on the package boundary.

It's a small usability thing, but if I was new to Node.js and these fields and saw a package.json with the above, the second one would make a lot more sense to me.