### PR TITLE
Imports proposal - first draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ We propose two fields in `package.json` to specify entrypoints and internal alia
 
 > **For both fields the final names of `"exports"` and `"imports"` are still TBD, and these names should be considered placeholders.**
 
-Both interfaces will only be respected for bare specifiers, e.g. `import _ from 'lodash'` where the specifier `'lodash'` doesn’t start with a `.` or `/`.
+These interfaces will only be respected for bare specifiers, e.g. `import _ from 'lodash'` where the specifier `'lodash'` doesn’t start with a `.` or `/`.
 
-Both features can be supported in both CommonJS and ES modules.
+Package _exports_ and _imports_ can be supported fully independently, and in both CommonJS and ES modules.
 
 ### 1. Exports Field
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ For the same example package as provided for `"exports"`, consider if we wanted 
 
 As with package exports, mappings are mapped relative to the package base, and keys that end in slashes can map to folder roots.
 
-The resolution algorithms remain the same except `"exports"` provide the added feature that they can also map into third-party packages that would be looked up in node_modules, including to subpaths that would be in turn resolved through `"exports"`. There is no risk of circular resolution here, since `"exports"` themselves only ever resolve to direct internal paths and can't in turn map to aliases.
+The resolution algorithms remain the same except `"imports"` provide the added feature that they can also map into third-party packages that would be looked up in node_modules, including to subpaths that would be in turn resolved through `"exports"`. There is no risk of circular resolution here, since `"exports"` themselves only ever resolve to direct internal paths and can't in turn map to aliases.
 
 The `"imports"` that apply within a given file are determined based on looking up the package boundary of that file.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,11 @@ import utc from '@momentjs/moment/timezones/utc/'; // Note trailing slash
 
 ### 2. Imports Field
 
-> **To avoid conflict with `node_modules` packages, the current proposal prefixes all imports with `#name`, so that the fact that an alias is being imported is clear. Whether this restriction is maintained in the final proposal, or what symbol is used is still TBD.**
+Imports provide the ability to remap bare specifiers within packages before they hit the node_modules resolution process.
+
+The current proposal prefixes all imports with `#` to provide a clear signal that it's a _symbolic specifier_ and also to prevent packages that use imports from working in any environment (runtime, bundler) that isn't aware of imports.
+
+> **Whether this restriction is maintained in the final proposal, or what exact symbol is used for `#` is still TBD.**
 
 #### Example
 


### PR DESCRIPTION
This provides details on the corresponding package `"imports"` proposal as the second field as part of this proposal, extending the similar types of mappings we have for `"exports"` into cases that can work for internal aliasing as well.

Notes have been provided where details are still to be determined, in particular whether or what custom symbol will be used for disambiguation in mappings.

Help fleshing out more edge cases in the examples here would be great.